### PR TITLE
Feature/token in kubecfg support

### DIFF
--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -147,6 +147,12 @@ class Config
             $config->setClientKeyPath($path);
         }
 
+        // Handles the case where you have a kubeconfig for a service account
+        if (!empty($user['token'])) {
+            $path = self::writeTempFile(base64_decode($user['token']));
+            $config->setToken($path);
+        }
+
         return $config;
     }
 

--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -149,8 +149,7 @@ class Config
 
         // Handles the case where you have a kubeconfig for a service account
         if (!empty($user['token'])) {
-            $path = self::writeTempFile(base64_decode($user['token']));
-            $config->setToken($path);
+            $config->setToken($user['token']);
         }
 
         return $config;


### PR DESCRIPTION
When you create a kubecfg from a ServiceAccount (like so https://gist.github.com/willnewby/7a1866147e036c0cfbd26b05efba9d70 for testing, etc) it sets a `token` field that wasn't used before. This includes that token in the config for making requests.