### PR TITLE
Take auth-provider command output into account when searching expiry|token key

### DIFF
--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -526,7 +526,7 @@ class Config
             $output = json_decode($output, true);
         }
 
-        if (!is_array($output)) {
+        if (!is_array($output) || empty($output)) {
             throw new \Error("error retrieving token: auth provider failed to return valid data");
         }
 
@@ -535,12 +535,12 @@ class Config
 
         if ($expiry_key) {
             $expiry_key = '$' . trim($expiry_key, "{}");
-            $this->setExpiry((new JSONPath($user))->find($expiry_key)[0]);
+            $this->setExpiry((new JSONPath($output))->find($expiry_key)[0]);
         }
 
         if ($token_key) {
             $token_key = '$' . trim($token_key, "{}");
-            $this->setToken((new JSONPath($user))->find($token_key)[0]);
+            $this->setToken((new JSONPath($output))->find($token_key)[0]);
         }
     }
 


### PR DESCRIPTION
For me, authenticated failed with a kubeconfig fetched via the Google SDK. (`gcloud container clusters get-credentials`) 
I found the `cmd-path` and `cmd-args` in the config, ran it manually and while studying `getAuthProviderToken()` I mentioned the 
commands output was fetched but never used.
I guess the fix is obvious.
I just hope I got it right, since I am quite new to all k8s and did not read through the whole auth docs, but as mentioned, it looks obvious (and works for me).