### PR TITLE
New feature: method Config::AutoConfig()

### DIFF
--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -171,6 +171,22 @@ class Config
     }
 
     /**
+     * Create a config based off running inside a cluster if corresponding files found.
+     * Otherwise try to create a config from KUBECONFIG env variable if present or ~/.kube/config.
+     *
+     * @return Config
+     * @throws \Exception If no config can be found at at all the default paths.
+     */
+    public static function AutoConfig()
+    {
+        try {
+            return self::InClusterConfig();
+        } catch (\Exception $e) {
+            return self::BuildConfigFromFile();
+        }
+    }
+
+    /**
      * Create a config based off running inside a cluster
      *
      * @return Config

--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -177,12 +177,12 @@ class Config
      * @return Config
      * @throws \Exception If no config can be found at at all the default paths.
      */
-    public static function AutoConfig()
+    public static function LoadFromDefault()
     {
         try {
-            return self::InClusterConfig();
-        } catch (\Exception $e) {
             return self::BuildConfigFromFile();
+        } catch (\Exception $e) {
+            return self::InClusterConfig();
         }
     }
 

--- a/src/KubernetesClient/Config.php
+++ b/src/KubernetesClient/Config.php
@@ -124,7 +124,7 @@ class Config
     /**
      * Create a temporary file to be used and destroyed at shutdown
      *
-     * @param $data
+     * @param  $data
      * @return bool|string
      */
     private static function writeTempFile($data)
@@ -154,9 +154,11 @@ class Config
     {
         if ((bool) $path && in_array($path, self::$tempFiles) && file_exists($path)) {
             unlink($path);
-            self::$tempFiles = array_filter(self::$tempFiles, function ($e) use ($path) {
-                return ($e !== $path);
-            });
+            self::$tempFiles = array_filter(
+                self::$tempFiles, function ($e) use ($path) {
+                    return ($e !== $path);
+                }
+            );
         }
     }
 
@@ -171,17 +173,17 @@ class Config
     }
 
     /**
-     * Create a config based off running inside a cluster if corresponding files found.
-     * Otherwise try to create a config from KUBECONFIG env variable if present or ~/.kube/config.
+     * Create a config from KUBECONFIG env variable if present or ~/.kube/config if found.
+     * Otherwise try to create a config based off running inside a cluster if corresponding files found.
      *
      * @return Config
-     * @throws \Exception If no config can be found at at all the default paths.
+     * @throws \Error If no config can be found at at all the default paths.
      */
     public static function LoadFromDefault()
     {
         try {
             return self::BuildConfigFromFile();
-        } catch (\Exception $e) {
+        } catch (\Error $e) {
             return self::InClusterConfig();
         }
     }
@@ -220,8 +222,8 @@ class Config
     /**
      * Create a config from file will auto fallback to KUBECONFIG env variable or ~/.kube/config if no path supplied
      *
-     * @param null $path
-     * @param null $contextName
+     * @param  null $path
+     * @param  null $contextName
      * @return Config
      * @throws \Error
      */


### PR DESCRIPTION
Convenience method to ease bootstrapping the config.
Just a simple method trying if in cluster config or config file config is to be found at the default locations and giving in cluster config precedence over config file variant. 

Requires PR #5 to work correctly.

While using in cluster config in production/staging, I guess many people might want to use config files in local development. This method eases such setups and helps with the distinction between hosting environments. (Which requires knowledge of k8s that should not concern bootstrapping code.)