### PR TITLE
Fix notice returning reference in DotAccess::get

### DIFF
--- a/src/KubernetesClient/Dotty/DotAccess.php
+++ b/src/KubernetesClient/Dotty/DotAccess.php
@@ -88,7 +88,10 @@ class DotAccess {
             $currentValue = &self::propGet($currentValue, $currentKey);
         }
 
-        return $currentValue === null ? $default : $currentValue;
+        if ($currentValue === null)
+            return $default;
+        else
+            return $currentValue;
     }
 
     public static function exists(&$currentValue, $key) {


### PR DESCRIPTION
Hey there!

Ran into an issue with the latest 0.4.x releases within Laravel. It presented as my watches seemingly registering and polling correctly, however they never actually called my callback with any events.

Tracking the problem down, I found in `Watch::internal_iterator` [any exceptions thrown are being caught and not handled](https://github.com/travisghansen/kubernetes-client-php/blob/7704a0ffa264df6bbd83da2b78591bdc5bbb2bca/src/KubernetesClient/Watch.php#L520) which led to no logging/output or other indication of a problem. Removing the try/catch, I was getting an exception thrown: `Only variable references should be returned by reference.`

This is likely to only apply to Laravel as it, by default, converts all PHP error logs into exceptions. Generally this would have gone to a log somewhere never to be seen again. However, it did uncover a potential problem.

The notice was being thrown by `DotAccess::get` [where it's returning the value](https://github.com/travisghansen/kubernetes-client-php/blob/7704a0ffa264df6bbd83da2b78591bdc5bbb2bca/src/KubernetesClient/Dotty/DotAccess.php#L91):

```php
return $currentValue === null ? $default : $currentValue;
```

While the function's declared to return a reference to a variable, because of the ternary this can only ever return a reference to the result of an expression. That is, this is effectively equivalent to doing: `function &add($n1, $n2) { return $n1 + $n2; }`. The reference returned isn't actually to the $currentValue / value returned from propGet. This can be minimally demonstrated with:

```php
<?php

class Example
{
	private array $my_data;

	public function __construct(array $my_data)
	{
		$this->my_data = $my_data;
	}

	public function &get(string $key, $default = null)
	{
		$value = &$this->my_data[$key];
		return $value === null ? $default : $value;
	}

}

$example = new Example(['a' => 1, 'b' => 2]);

$a = &$example->get('a'); // triggers a NOTICE
$a = 5;

var_dump($example->get('a')); // outputs 1
```

If you swap out the arrays in the example for objects, they exhibit the same issue. In both cases, the attached diff will correctly return the variable reference instead of a reference to the result of the expression--making the method match what appears to be intended behaviour and also allow watches to work again in Laravel and other frameworks that treat PHP's errors more severely.

Cheers, and thank you! Been using this lib for a bit to hack away at things on my home cluster. Appreciate the work you've put in.