### PR TITLE
Default to not escaping forward slashes in JSON

### DIFF
--- a/src/KubernetesClient/Client.php
+++ b/src/KubernetesClient/Client.php
@@ -227,7 +227,7 @@ class Client
      */
     public function getRequestOption($option, $options) {
         $defaults = [
-            'encode_flags' => 0,
+            'encode_flags' => \JSON_UNESCAPED_SLASHES,
             'decode_flags' => 0,
             'decode_response' => true,
             'decode_associative' => true,


### PR DESCRIPTION
Hi me again,

This patch updates the default JSON encode flags to disable escaping forward slashes. (By default, `json_encode("my/string")` -> `my\/string`.)

This appears to be mainly a PHP oddity to reduce the risk when embedding the JSON in a web page. It prevents a string containing something like `</script>` from interacting with the DOM. This doesn't really apply at all anywhere in this library.

However, in trying to make use of server-side apply I did discover that while `my\/string` is valid _JSON_, it is _not_ valid YAML. So, contrary to the k8s docs' statement that "All JSON documents are valid YAML." I was unable to apply a patch with typical URI-style tags. `my.domain/tag: value` would be encoded to `"my.domain\/tag": "value"`, and the patch would fail with:

```
error decoding YAML: error converting YAML to JSON: yaml: found unknown escape character
```

The JSON generated _is_ valid YAML per RFC8259, however this seems to be an open and longstanding bug in the go-yaml parser used by kubernetes (and shared by yq which exhibits similar behaviour). Probably easier to work around it here rather than waiting for them to merge the PRs that have been sitting for a couple years.

There's no case for escaping forward-slashes outside of a document sent to a browser, and there are definitely cases where it causes issues talking to k8s. So while the caller _can_ specify these options, it seems that making this one a default could make things less surprising.

Thank you!

Adam