### PR TITLE
Send apply-patch+yaml body as YAML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.2.0",
         "ext-json": "*",
-        "symfony/yaml": "^6.3",
+        "symfony/yaml": "^6.3|^7.0",
         "softcreatr/jsonpath": "^0.8.3"
     },
     "suggest": {


### PR DESCRIPTION
Hello!

This MR introduces the ability for different verbs to use different formats for the body. Everything is encoded as it was (JSON), except for the recently added `PATCH-APPLY` which now uses yaml.

I didn't add any sort of YAML-equivalent of `encode_flags` because that would require trying to align the flags for both `yaml_emit` (basically none) and `symfony/yaml`. Instead I've done my best to align symfony/yaml with `yaml_emit` to avoid any weird issues of "it works on my machine" if someone does/doesn't have the yaml extension installed. Though I'm basically just running a dozen random YAML files I have laying around through this to see if any throw an error with one and not the other.

I've also updated the version constraint for symfony/yaml to allow for 7.x. I'm also not able to test this comprehensively or anything, but a review of the changelog from 6.3 to 7.0.3 doesn't show anything that looks too concerning, and it still works with my .kube/config.

As a total aside, thanks again for your work on this lib and for being so responsive to changes. I've been using it for a few projects, and lately have started trying to pull out some of what I've built on top into its own library. It's still a WIP, being developed alongside some other as-of-yet unreleased tooling, but if you're ever interested [this is what I've been working on](https://gitlab.com/nucleardog/php-k8s).

Cheers,

Adam