### PR TITLE
Remove softcreatr/jsonpath: ^0.8.3 requirement from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "require": {
         "php": ">=7.2.0",
         "ext-json": "*",
-        "symfony/yaml": "^6.3|^7.0",
-        "softcreatr/jsonpath": "^0.8.3"
+        "symfony/yaml": "^6.3|^7.0"
     },
     "suggest": {
         "ext-pcntl": "support forking of watches",


### PR DESCRIPTION
jsonpath is no longer used in the code favouring instead a simpler internal Dotty.

Therefore the json path should be removed.